### PR TITLE
Prevent repeat sounds while holding down keys

### DIFF
--- a/lib/key-sound.coffee
+++ b/lib/key-sound.coffee
@@ -16,4 +16,4 @@ class KeySound
     buffer.volume = 0.2 for buffer in @buffers
 
   play: ->
-    @buffers[@index++ % NUM_BUFFERS].play()
+    event.repeat || @buffers[@index++ % NUM_BUFFERS].play()


### PR DESCRIPTION
In order to simulate the sound of key presses only, play sound on key down without repeating except when auto-repeating. 
